### PR TITLE
Ensure urls from url fetcher are distinct

### DIFF
--- a/packages/ember-build-prerender/lib/utils/prerender.js
+++ b/packages/ember-build-prerender/lib/utils/prerender.js
@@ -201,7 +201,7 @@ class Prerender {
     });
 
     let urls = (this.urls || []).concat(newUrls);
-    this.urls = urls;
+    this.urls = [...new Set(urls)];
 
     page.close();
     ui.stopProgress();


### PR DESCRIPTION
To avoid prerendering a page multiple times.