### PR TITLE
Ensure urlFetcher is properly passed in deploy plugin

### DIFF
--- a/packages/ember-cli-deploy-prerender/index.js
+++ b/packages/ember-cli-deploy-prerender/index.js
@@ -33,7 +33,10 @@ module.exports = {
         let port = this.readConfig('port');
         let viewportWidth = this.readConfig('viewportWidth');
         let viewportHeight = this.readConfig('viewportHeight');
-        let urlFetcher = this.readConfig('urlFetcher');
+
+        // This is supposed to be a function, so we cannot use readConfig() here
+        // As this will evaluate the function at runtime and take the function return value
+        let urlFetcher = this.pluginConfig.urlFetcher || undefined;
 
         let Builder = this.project.require('ember-cli/lib/models/builder');
 


### PR DESCRIPTION
`this.readConfig()` in the plugin is built to interpret a function as "evaluate me at runtime and take the return value as config". Instead, we want to actually pass a function here, so we cannot use it.