### PR TITLE
Ensure empty file prerender state works no matter how meta tag looks

### DIFF
--- a/packages/ember-build-prerender/lib/utils/fix-prerender-in-empty-file.js
+++ b/packages/ember-build-prerender/lib/utils/fix-prerender-in-empty-file.js
@@ -1,0 +1,6 @@
+module.exports = function fixPrerenderInEmptyFile(emptyFileContent) {
+  return emptyFileContent.replace(
+    '<meta name="prerender-config" content="should-prerender"',
+    '<meta name="prerender-config" content="skip"'
+  );
+};

--- a/packages/ember-build-prerender/lib/utils/merge-prerender.js
+++ b/packages/ember-build-prerender/lib/utils/merge-prerender.js
@@ -1,4 +1,5 @@
 const fs = require('fs-extra');
+const fixPrerenderInEmptyFile = require('./fix-prerender-in-empty-file');
 const path = require('path');
 
 module.exports = async function mergePrerender({
@@ -14,10 +15,8 @@ module.exports = async function mergePrerender({
 
   // Remove prerender config from empty file
   let emptyFileContent = await fs.readFile(emptyFilePath, 'utf-8');
-  emptyFileContent = emptyFileContent.replace(
-    '<meta name="prerender-config" content="should-prerender"></meta>',
-    '<meta name="prerender-config" content="skip"></meta>'
-  );
+  emptyFileContent = fixPrerenderInEmptyFile(emptyFileContent);
+
   await fs.writeFile(emptyFilePath, emptyFileContent, 'utf-8');
 
   await fs.remove(buildDir);

--- a/packages/test-app/node-tests/unit/fix-prerender-in-empty-file-test.js
+++ b/packages/test-app/node-tests/unit/fix-prerender-in-empty-file-test.js
@@ -1,0 +1,48 @@
+const { expect } = require('chai');
+const fixPrerenderInEmptyFile = require('ember-build-prerender/lib/utils/fix-prerender-in-empty-file');
+
+describe('fix-prerender-in-empty-file', function () {
+  it('it works with empty string', async function () {
+    let source = ``;
+    let expected = ``;
+    let result = fixPrerenderInEmptyFile(source);
+
+    expect(result).to.equal(expected);
+  });
+
+  it('it works with self-closing tag', async function () {
+    let source = `
+<meta name="prerender-config" content="should-prerender" />
+<meta name="other" content="should-prerender" />`;
+    let expected = `
+<meta name="prerender-config" content="skip" />
+<meta name="other" content="should-prerender" />`;
+    let result = fixPrerenderInEmptyFile(source);
+
+    expect(result).to.equal(expected);
+  });
+
+  it('it works with closing tag', async function () {
+    let source = `
+<meta name="prerender-config" content="should-prerender"></meta>
+<meta name="other" content="should-prerender"></meta>`;
+    let expected = `
+<meta name="prerender-config" content="skip"></meta>
+<meta name="other" content="should-prerender"></meta>`;
+    let result = fixPrerenderInEmptyFile(source);
+
+    expect(result).to.equal(expected);
+  });
+
+  it('it works with only open tag', async function () {
+    let source = `
+<meta name="prerender-config" content="should-prerender">
+<meta name="other" content="should-prerender">`;
+    let expected = `
+<meta name="prerender-config" content="skip">
+<meta name="other" content="should-prerender">`;
+    let result = fixPrerenderInEmptyFile(source);
+
+    expect(result).to.equal(expected);
+  });
+});


### PR DESCRIPTION
It seems in newer versions of puppeteer, it can be serialized as `<meta>` without closing tag, which breaks with the current setup.

Now, we handle open, open+close, and self-closing tags.